### PR TITLE
Support the same basenotify object to register the preprocessing function and common processing function for the same command

### DIFF
--- a/cpp/servant/libservant/BaseNotify.cpp
+++ b/cpp/servant/libservant/BaseNotify.cpp
@@ -3,14 +3,14 @@
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
  *
- * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except 
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
  * https://opensource.org/licenses/BSD-3-Clause
  *
- * Unless required by applicable law or agreed to in writing, software distributed 
- * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 
@@ -20,11 +20,11 @@
 namespace tars
 {
 
-BaseNotify::BaseNotify() 
+BaseNotify::BaseNotify()
 {
 }
 
-BaseNotify::~BaseNotify() 
+BaseNotify::~BaseNotify()
 {
 }
 
@@ -32,7 +32,7 @@ void BaseNotify::addAdminCommandPrefix(const string& command, TAdminFunc func)
 {
     TC_LockT<TC_ThreadRecMutex> lock(*this);
 
-    _procFunctors.insert(std::make_pair(command, func));
+    _preProcFunctors.insert(std::make_pair(command, func));
 
     NotifyObserver::getInstance()->registerPrefix(command, this);
 }
@@ -46,15 +46,17 @@ void BaseNotify::addAdminCommandNormal(const string& command, TAdminFunc func)
     NotifyObserver::getInstance()->registerNotify(command, this);
 }
 
-bool BaseNotify::notify(const string& cmd, const string& params, TarsCurrentPtr current, string& result)
+bool BaseNotify::notify(const string& cmd, const string& params, TarsCurrentPtr current, bool isPrefix, string& result)
 {
     TC_LockT<TC_ThreadRecMutex> lock(*this);
 
     map<string, TAdminFunc>::iterator it;
 
-    it =  _procFunctors.find(cmd);
+    auto &curProcFunctors = isPrefix ? _preProcFunctors : _procFunctors;
 
-    if (it != _procFunctors.end())
+    it =  curProcFunctors.find(cmd);
+
+    if (it != curProcFunctors.end())
     {
         return (it->second)(cmd, params, result);
     }

--- a/cpp/servant/libservant/NotifyObserver.cpp
+++ b/cpp/servant/libservant/NotifyObserver.cpp
@@ -3,14 +3,14 @@
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
  *
- * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except 
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
  * https://opensource.org/licenses/BSD-3-Clause
  *
- * Unless required by applicable law or agreed to in writing, software distributed 
- * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 
@@ -113,7 +113,7 @@ string NotifyObserver::notify(const string& command, TarsCurrentPtr current)
         {
             string result = "";
 
-            if ((*sit)->notify(name, params, current, result))
+            if ((*sit)->notify(name, params, current, true, result))
             {
                 os << "[" << ++i << "]:" << result << endl;
             }
@@ -141,7 +141,7 @@ string NotifyObserver::notify(const string& command, TarsCurrentPtr current)
         {
             string result = "";
 
-            if ((*sit)->notify(name, params, current, result))
+            if ((*sit)->notify(name, params, current, false, result))
             {
                 os << "[" << ++i << "]:" << result << endl;
             }

--- a/cpp/servant/servant/BaseNotify.h
+++ b/cpp/servant/servant/BaseNotify.h
@@ -3,14 +3,14 @@
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
  *
- * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except 
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
  * https://opensource.org/licenses/BSD-3-Clause
  *
- * Unless required by applicable law or agreed to in writing, software distributed 
- * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 
@@ -49,7 +49,7 @@ public:
      * @param result
      * @return bool
      */
-    bool notify(const string& command, const string& params, TarsCurrentPtr current, string& result);
+    bool notify(const string& command, const string& params, TarsCurrentPtr current, bool isPrefix, string& result);
 
     /**
      * 处理命令的函数类型
@@ -75,9 +75,15 @@ public:
 
 protected:
     /**
-     * 命令处理方法
+     * 普通命令处理方法
      */
     map<string, TAdminFunc> _procFunctors;
+
+    /**
+     * 前置命令处理方法
+     */
+    map<string, TAdminFunc> _preProcFunctors;
+
 };
 /////////////////////////////////////////////////////////////////////
 }


### PR DESCRIPTION
After I registered the tars CMD load config command in the initialize function of the application derived object (such as xxxserver), the default registration function application:: cmdloadconfig of the framework will not be called, resulting in the command losing the function of automatically updating the config file. After troubleshooting, I found that the same map was used to store the event handling function in the basenotify class 。 This implementation seems to be inconsistent with the description in the document, so I modified the code to support the same basenotify object to register the preprocessing function and common processing function for the same command.