### PR TITLE
php 扩展 http 请求处理

### DIFF
--- a/php/tars-server/src/core/Server.php
+++ b/php/tars-server/src/core/Server.php
@@ -122,6 +122,12 @@ class Server
 
         require_once $this->entrance;
 
+        // 扩展 server 的 请求处理 ,增加自定义进程
+        if ($this->servicesInfo["onInitServer"]) {
+            $this->servicesInfo["onInitServer"]($this->sw , $this->tarsConfig);
+        }
+
+
         $this->sw->start();
     }
 


### PR DESCRIPTION
 用于 扩展的自定义的开发环境 代码更新马上生效. 用protobuf 定义的协议 代码生成和展示

onInitServer 的例子代码在:
xcwen/Tars@3fcf4a2
tars-http-server + protobuf 例子代码:
https://github.com/xcwen/Tars/tree/php-http-extends/php/examples/tars-http-server-protobuf

onInitServer  放在这里servicesInfo有点不好. 目标是可以扩展 .

还有,能不能支持websocket